### PR TITLE
fix toc always showing

### DIFF
--- a/static/js/toc.js
+++ b/static/js/toc.js
@@ -131,10 +131,8 @@ const tableOfContents = {
   },
 
   getParam: (sname) => {
-    let sval = true;
-    const urlParams = new URLSearchParams(location.href);
-    if (urlParams.get(sname) === 'false') sval = false;
-    return sval;
+    const urlParams = new URLSearchParams(window.location.search);
+    return urlParams.has(sname);
   },
 
 };


### PR DESCRIPTION
checking for toc parameter in url was failing and always returning true. this meant that any configuration of disable_by_default was ignored. this seems to work.